### PR TITLE
fix: validate sync sales invoice at the fucntion start to aviod unneccessary failure log creation

### DIFF
--- a/ecommerce_integrations/shopify/invoice.py
+++ b/ecommerce_integrations/shopify/invoice.py
@@ -18,7 +18,8 @@ def prepare_sales_invoice(payload, request_id=None):
 	frappe.set_user("Administrator")
 	setting = frappe.get_doc(SETTING_DOCTYPE)
 	frappe.flags.request_id = request_id
-
+	if not cint(setting.sync_sales_invoice):
+		return
 	try:
 		sales_order = get_sales_order(cstr(order["id"]))
 		if sales_order:


### PR DESCRIPTION
Validate sync sales invoice